### PR TITLE
[codex] fix stale Cloudflare calendar cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Setup steps:
 4. Deploy from the repo root with `npx wrangler deploy`.
 5. Subscribe iCloud or any other calendar client to the Worker URL.
 
+When the repository is connected to Cloudflare, merging to the configured production branch triggers the Cloudflare build and deploy. The Worker compares the bundled deploy-time calendar timestamp with `CALENDAR_CACHE`; if KV is stale, it serves the fresh bundled calendar and refreshes KV in the background so subscribers receive the new feed without waiting for the monthly cron.
+
 ## Repository Automation
 [update-calendar.yml](/Users/as082003/IdeaProjects/calendar/.github/workflows/update-calendar.yml) is validation-only. It checks formatting, linting, typing, tests, and a dry-run calendar build on pushes and pull requests.
 

--- a/cloudflare/scripts/smoke-fetch.mjs
+++ b/cloudflare/scripts/smoke-fetch.mjs
@@ -49,6 +49,30 @@ const headResponse = await worker.fetch(new Request("https://calendar.corncob.ap
 assert(headResponse.status === 200, "Expected HEAD / to succeed");
 assert((await headResponse.text()) === "", "Expected empty HEAD body");
 
+await kv.put("calendar:body", "STALE CALENDAR");
+await kv.put("calendar:generated_at", "2000-01-01T00:00:00.000Z");
+const refreshTasks = [];
+const staleKvResponse = await worker.fetch(new Request("https://calendar.corncob.app"), env, {
+  waitUntil(promise) {
+    refreshTasks.push(promise);
+  },
+});
+assert(
+  staleKvResponse.headers.get("x-calendar-source") === "bundle",
+  "Expected fresh bundle over stale KV"
+);
+assert(
+  (await staleKvResponse.text()).includes("BEGIN:VCALENDAR"),
+  "Expected bundled iCalendar body"
+);
+await Promise.all(refreshTasks);
+assert((await kv.get("calendar:body")).includes("BEGIN:VCALENDAR"), "Expected stale KV to refresh");
+assert(
+  (await kv.get("calendar:generated_at")) ===
+    staleKvResponse.headers.get("x-calendar-generated-at"),
+  "Expected stale KV timestamp to refresh"
+);
+
 const scheduledTasks = [];
 await worker.scheduled(
   { cron: "0 0 1 * *" },

--- a/cloudflare/src/runtime.js
+++ b/cloudflare/src/runtime.js
@@ -6,6 +6,8 @@ const CALENDAR_BODY_KEY = "calendar:body";
 const CALENDAR_GENERATED_AT_KEY = "calendar:generated_at";
 
 export function createWorker({ bundledHolidayYaml, bundledCalendar, bundledGeneratedAt }) {
+  const bundledGeneratedAtValue = bundledGeneratedAt.trim() || null;
+
   function loadHolidayConfig() {
     const config = yaml.load(bundledHolidayYaml);
     validateHolidayConfig(config);
@@ -23,16 +25,46 @@ export function createWorker({ bundledHolidayYaml, bundledCalendar, bundledGener
     return env.CALENDAR_CACHE ?? null;
   }
 
-  async function storeCalendar(env, generatedAt = new Date().toISOString()) {
+  async function storeCalendarBody(env, calendar, generatedAt) {
     const namespace = getKvNamespace(env);
     if (!namespace) {
       throw new Error("CALENDAR_CACHE binding is not configured");
     }
 
-    const calendar = generateCalendar(env);
     await namespace.put(CALENDAR_BODY_KEY, calendar);
     await namespace.put(CALENDAR_GENERATED_AT_KEY, generatedAt);
     return { body: calendar, generatedAt, source: "kv" };
+  }
+
+  async function storeCalendar(env, generatedAt = new Date().toISOString()) {
+    return storeCalendarBody(env, generateCalendar(env), generatedAt);
+  }
+
+  function parseGeneratedAt(value) {
+    if (!value) {
+      return null;
+    }
+
+    const timestamp = Date.parse(value);
+    return Number.isNaN(timestamp) ? null : timestamp;
+  }
+
+  function isBundledCalendarNewer(generatedAt) {
+    const bundledTimestamp = parseGeneratedAt(bundledGeneratedAtValue);
+    if (bundledTimestamp === null) {
+      return false;
+    }
+
+    const storedTimestamp = parseGeneratedAt(generatedAt);
+    return storedTimestamp === null || bundledTimestamp > storedTimestamp;
+  }
+
+  async function refreshStaleKv(env) {
+    if (!bundledGeneratedAtValue) {
+      return null;
+    }
+
+    return storeCalendarBody(env, bundledCalendar, bundledGeneratedAtValue);
   }
 
   async function loadServedCalendar(env) {
@@ -42,15 +74,23 @@ export function createWorker({ bundledHolidayYaml, bundledCalendar, bundledGener
         namespace.get(CALENDAR_BODY_KEY),
         namespace.get(CALENDAR_GENERATED_AT_KEY),
       ]);
-      if (body) {
-        return { body, generatedAt, source: "kv" };
+      if (body && !isBundledCalendarNewer(generatedAt)) {
+        return { body, generatedAt, source: "kv", refreshKv: false };
       }
+
+      return {
+        body: bundledCalendar,
+        generatedAt: bundledGeneratedAtValue,
+        source: "bundle",
+        refreshKv: Boolean(bundledGeneratedAtValue),
+      };
     }
 
     return {
       body: bundledCalendar,
-      generatedAt: bundledGeneratedAt.trim() || null,
+      generatedAt: bundledGeneratedAtValue,
       source: "bundle",
+      refreshKv: false,
     };
   }
 
@@ -70,7 +110,7 @@ export function createWorker({ bundledHolidayYaml, bundledCalendar, bundledGener
   }
 
   return {
-    async fetch(request, env) {
+    async fetch(request, env, ctx) {
       const url = new URL(request.url);
       if (request.method !== "GET" && request.method !== "HEAD") {
         return new Response("Method Not Allowed", { status: 405 });
@@ -80,7 +120,10 @@ export function createWorker({ bundledHolidayYaml, bundledCalendar, bundledGener
         return new Response("ok");
       }
 
-      const { body, generatedAt, source } = await loadServedCalendar(env);
+      const { body, generatedAt, source, refreshKv } = await loadServedCalendar(env);
+      if (refreshKv && ctx) {
+        ctx.waitUntil(refreshStaleKv(env));
+      }
 
       if (request.method === "HEAD") {
         return calendarResponse("", generatedAt, source);


### PR DESCRIPTION
## Summary

Fixes the Cloudflare-connected deployment path for the calendar Worker.

The repository is already connected in Cloudflare, so deploying from GitHub is not the missing step. The issue is that the Worker serves `CALENDAR_CACHE` first. After a Cloudflare-connected deploy, KV can still contain an older `calendar:body`, causing subscribers to keep receiving stale calendar data until the monthly cron refresh runs.

This change makes the Worker compare the bundled deploy-time calendar timestamp with the stored KV timestamp. If the bundled calendar is newer, the Worker serves the fresh bundled calendar immediately and refreshes KV in the background.

## Validation

- `poetry run pytest -q` passed with 21 tests.
- `npm run worker:verify` passed.
- Worker smoke coverage now includes stale-KV refresh behavior.
